### PR TITLE
Refactor Get to use jsonptr.Pointer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/arnumina/dataptr
 go 1.14
 
 require (
-	github.com/arnumina/failure v0.0.0-20200708203355-cff5fdeb8241
+	github.com/arnumina/failure v0.0.0-20200712145805-92d1fe949ac6
 	github.com/dolmen-go/jsonptr v0.0.0-20200427210345-20e1608f9d85
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/arnumina/failure v0.0.0-20200708203355-cff5fdeb8241 h1:ddGLawkZRFlTEyAufR7pbOA7+Kiq1QAR+qC4D1TYF3I=
 github.com/arnumina/failure v0.0.0-20200708203355-cff5fdeb8241/go.mod h1:JGykkj7wLVBbuTzuAgSpwIzPHiG3J8VeiwJFqrsTR8E=
+github.com/arnumina/failure v0.0.0-20200712145805-92d1fe949ac6 h1:mG368Thv5t6zONfNUmzJOI6jMXQFulcXuL3thG4AoRM=
+github.com/arnumina/failure v0.0.0-20200712145805-92d1fe949ac6/go.mod h1:lsRyz6YJxNpgzBe7dEkI+Y+9VR43v7vVrZwpfqCtLtA=
 github.com/arnumina/logfmt v0.0.0-20200708202956-75290b26d333 h1:A86G9qAH8Gs2G7uBynIlc8M868t5oNQ4HiqL8FJWShM=
 github.com/arnumina/logfmt v0.0.0-20200708202956-75290b26d333/go.mod h1:AeTbgRS8lCSNc2PNFADFsGz7hWop7PGJh3dv2cDWqQ8=
+github.com/arnumina/logfmt v0.0.0-20200712130836-867c8dd4b690 h1:6G9aYff0ejsfgbdHrRiPUBQV101kp7v7OKIvTmAqvGI=
+github.com/arnumina/logfmt v0.0.0-20200712130836-867c8dd4b690/go.mod h1:AeTbgRS8lCSNc2PNFADFsGz7hWop7PGJh3dv2cDWqQ8=
 github.com/dolmen-go/jsonptr v0.0.0-20200427210345-20e1608f9d85 h1:UehF9pCOF1JiOLmeZavootTCuimvkW7N1wggjyW4S90=
 github.com/dolmen-go/jsonptr v0.0.0-20200427210345-20e1608f9d85/go.mod h1:+6ZQtcQuiOH4ATMF+4885rhnE3FaM++MhE7m7vM302s=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Use [jsonptr.Pointer](https://pkg.go.dev/github.com/dolmen-go/jsonptr#Pointer) instead of just string concatenation to build the JSON pointer.
This allows:
* proper handling of properties containing '/' or '~' characters
* faster navigation
    
Note 1: the non-standard behavior of exposing the root of the document as pointer "/" instead of "" is preserved.

Note 2: I'm the author of the [jsonptr](https://pkg.go.dev/github.com/dolmen-go/jsonptr) package.

Note 3: merge #1 first.

